### PR TITLE
Correctly expand absolute paths for `link_lib`

### DIFF
--- a/lib/zig/assembler.ex
+++ b/lib/zig/assembler.ex
@@ -53,7 +53,7 @@ defmodule Zig.Assembler do
   defp adjust_link_lib(link_lib, from) do
     Enum.map(link_lib, fn
       {:system, _} = system -> system
-      lib -> Path.join(from, lib)
+      lib -> Path.expand(lib, from)
     end)
   end
 end


### PR DESCRIPTION
Otherwise absolute paths will be appended to the project path.