### PR TITLE
Update to Zig 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ by adding `zigler` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:zigler, "~> 0.12.1", runtime: false}
+    {:zigler, "~> 0.13.0", runtime: false}
   ]
 end
 ```
@@ -43,7 +43,7 @@ have difficulty.
 ```erlang
 {plugins, [rebar_mix]}.
 
-{deps, [{zigler, "0.12"}]}.
+{deps, [{zigler, "0.13"}]}.
 
 ```
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -135,6 +135,9 @@ Thanks to Dave Cottlehuber @dch for testing.
 - smarter `beam.send`
 - attributes imported as compile-time values
 
+## 0.13.0
+- updated to zig 0.13.0
+
 ## Upcoming
 - `precompiled` mode that will let you obtain packages with precompiled assets.
 - Breaking changes:

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -6,7 +6,7 @@ end
 defmodule Zig.Get.MixProject do
   use Mix.Project
 
-  @version "0.12.2"
+  @version "0.13.0"
   @scm_url "https://github.com/e-xyza/zigler"
 
   @elixir_requirement "~> 1.14"

--- a/installer/mix.tasks/zig.get.ex
+++ b/installer/mix.tasks/zig.get.ex
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Zig.Get do
     end
   end
 
-  @default_version "0.12.1"
+  @default_version "0.13.0"
 
   defp defaults do
     {os, arch} = Zig.Get.os_info()

--- a/lib/zig/templates/build.zig.eex
+++ b/lib/zig/templates/build.zig.eex
@@ -90,7 +90,7 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addSharedLibrary(.{
         .name = "<%= @module %>",
-        .root_source_file = .{.path = "module.zig"},
+        .root_source_file = .{ .src_path = .{ .owner = b, .sub_path = "module.zig"} },
         .version = .{.major = <%= @version.major %>,
                      .minor = <%= @version.minor %>,
                      .patch = <%= @version.patch %>},

--- a/lib/zig/type/enum.ex
+++ b/lib/zig/type/enum.ex
@@ -82,7 +82,7 @@ defmodule Zig.Type.Enum do
 
   defp accumulate(number, []), do: [number]
   defp accumulate(number, [succ | rest]) when succ == number + 1, do: [number..succ | rest]
-  defp accumulate(number, [succ..last | rest]) when succ == number + 1, do: [number..last | rest]
+  defp accumulate(number, [succ..last//_ | rest]) when succ == number + 1, do: [number..last | rest]
   defp accumulate(number, noncontiguous), do: [number | noncontiguous]
 
   defp unionize(content) do
@@ -95,7 +95,7 @@ defmodule Zig.Type.Enum do
     end)
   end
 
-  defp rerender(a..b) do
+  defp rerender(a..b//_) do
     quote do
       unquote(a)..unquote(b)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zigler.MixProject do
   use Mix.Project
 
-  def zig_version, do: "0.12.1"
+  def zig_version, do: "0.13.0"
 
   def project do
     env = Mix.env()
@@ -72,7 +72,7 @@ defmodule Zigler.MixProject do
       {:zig_parser, "~> 0.4.0"},
       # utility to help manage type protocols
       {:protoss, "~> 0.2"},
-      {:zig_get, "~> 0.12.1"},
+      {:zig_get, path: "installer"},
       # documentation
       {:markdown_formatter, "~> 0.6", only: :dev, runtime: false},
       {:zig_doc, "~> 0.4.0", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -14,6 +14,5 @@
   "pegasus": {:hex, :pegasus, "0.2.5", "38123461fe41add54f715ce41f89137a31cd217d353005b057f88b9b67c39b6f", [:mix], [{:nimble_parsec, "~> 1.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "ee80708608807f4447f1da1e6e0ebd9604f5bda4fbe2d4bdd9aa6dd67afde020"},
   "protoss": {:hex, :protoss, "0.2.1", "fcf437ed65178d6cbf9a600886e3da9f7173697223972f062ee593941c2588b1", [:mix], [], "hexpm", "2261dbdc4d5913ce1e88d1410108d97f21140a118f45f6acc3edc4ecdb952052"},
   "zig_doc": {:hex, :zig_doc, "0.4.0", "fdaee133165fa3c3a17e8ff7d62ab60be4ad011ff128d567151dbca2026f44d0", [:mix], [{:ex_doc, "~> 0.34.2", [hex: :ex_doc, repo: "hexpm", optional: false]}, {:zig_parser, "~> 0.4.0", [hex: :zig_parser, repo: "hexpm", optional: false]}], "hexpm", "d07c69a210d7ae3732493bf7e55628e30c4a68fec47c244e3f40f6c7323b819d"},
-  "zig_get": {:hex, :zig_get, "0.12.2", "713de7f73c508386e7ac93c8479b1e196a24834c95fd03f1dd3dc8133857c063", [:mix], [{:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "81a5c562fdef8b4affd28a94a41a725c355b26021f5a8ddb550f19d319aa3010"},
   "zig_parser": {:hex, :zig_parser, "0.4.0", "5230576fcea30c061f08f6053448ad3dc5194a45485065564a7f8047bb351ce9", [:mix], [{:pegasus, "~> 0.2.4", [hex: :pegasus, repo: "hexpm", optional: false]}], "hexpm", "ec54cf14e80a1485e29a80b42756d0421426db81eb9e2630721fd46ab5c21bcb"},
 }

--- a/test/_support/compiler.ex
+++ b/test/_support/compiler.ex
@@ -27,7 +27,12 @@ defmodule ZiglerTest.Compiler do
   end
 
   def compile_erlang(file) do
-    {:ok, mod} = :compile.file(file, [:return_errors, outdir: :code.lib_dir(:zigler, :ebin)])
+    {:ok, mod} =
+      :compile.file(file, [
+        :return_errors,
+        outdir: :filename.join(:code.lib_dir(:zigler), ~c"ebin")
+      ])
+
     Code.ensure_loaded(mod)
   end
 end

--- a/test/_support/spec_template.ex
+++ b/test/_support/spec_template.ex
@@ -14,7 +14,7 @@ defmodule ZiglerTest.SpecTemplate do
     end
   end
 
-  defp convert(a..b, context) do
+  defp convert(a..b//_, context) do
     quote do
       {:type, _, :range, [unquote(convert(a, context)), unquote(convert(b, context))]}
     end


### PR DESCRIPTION
Mostly version bumping plus a single line change in the `build.zig` template.
Also cleanup Elixir 1.17 warnings.