### PR TITLE
Various small fixes

### DIFF
--- a/lib/zig/_c.ex
+++ b/lib/zig/_c.ex
@@ -51,10 +51,7 @@ defmodule Zig.C do
   defp solve_relative({:system, _} = system, _), do: system
 
   defp solve_relative(file, module_file) do
-    module_file
-    |> Path.dirname()
-    |> Path.join(file)
-    |> Path.expand()
+    Path.expand(file, module_file)
   end
 
   defp normalize_src(file, module_file) when is_binary(file) do

--- a/lib/zig/templates/build.zig.eex
+++ b/lib/zig/templates/build.zig.eex
@@ -74,7 +74,7 @@ pub fn build(b: *std.Build) void {
         <% {:system, lib} -> %>
     nif.linkSystemLibrary("<%= lib %>", .{});
         <% lib -> %>
-    nif.addObjectFile("<%= lib %>");
+    nif.addObjectFile(.{.cwd_relative = "<%= lib %>"});
       <% end %>
     <% end %>
     <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -46,11 +46,9 @@ defmodule Zigler.MixProject do
   end
 
   defp guides() do
-    "guides"
-    |> File.ls!()
-    |> Enum.sort()
-    |> Enum.filter(&String.ends_with?(&1, ".md"))
-    |> Enum.map(&Path.join("guides", &1))
+    "guides/*.md"
+    |> Path.wildcard()
+    |> Enum.map(&Path.join("guides", Path.basename(&1, ".md")))
   end
 
   def application, do: [extra_applications: [:logger, :inets, :crypto, :public_key, :ssl]]


### PR DESCRIPTION
Allows our project to build with the upgraded zigler.

## Fixes

* Guides are not available in published package, adapted the code to be able to deal with that.
* `addObjectFile` expects a `LazyPath`
* Correctly expand path to `include_dirs`