### PR TITLE
Add library_dirs and update target arch rules

### DIFF
--- a/lib/zig/_c.ex
+++ b/lib/zig/_c.ex
@@ -5,12 +5,14 @@ defmodule Zig.C do
   # c-interoperability with zigler
 
   defstruct include_dirs: [],
+            library_dirs: [],
             src: [],
             link_lib: [],
             link_libcpp: false
 
   @type t :: %__MODULE__{
           include_dirs: [Path.t()],
+          library_dirs: [Path.t()],
           link_lib: [Path.t()],
           link_libcpp: boolean,
           src: src_opts()
@@ -18,6 +20,7 @@ defmodule Zig.C do
 
   @type opts :: [
           include_dirs: Path.t() | [Path.t()],
+          library_dirs: Path.t() | [Path.t()],
           link_lib: Path.t() | [Path.t()],
           link_libcpp: boolean,
           src: src_opts()
@@ -33,6 +36,7 @@ defmodule Zig.C do
 
     struct!(__MODULE__,
       include_dirs: normalize_filelist(opts, :include_dirs, module_dir),
+      library_dirs: normalize_filelist(opts, :library_dirs, module_dir),
       link_lib: normalize_filelist(opts, :link_lib, module_dir),
       link_libcpp: Keyword.get(opts, :link_libcpp, false),
       src: normalized_srclist(opts, module_dir)

--- a/lib/zig/target.ex
+++ b/lib/zig/target.ex
@@ -21,14 +21,12 @@ defmodule Zig.Target do
   # obtains the target from the
   @spec resolve() :: nil | t
   def resolve do
-    unless function_exported?(Mix, :target, 0) and Mix.target() === :host do
-      arch = System.get_env("TARGET_ARCH")
-      os = System.get_env("TARGET_OS")
-      abi = System.get_env("TARGET_ABI")
+    arch = System.get_env("TARGET_ARCH")
+    os = System.get_env("TARGET_OS")
+    abi = System.get_env("TARGET_ABI")
 
-      if arch && os && abi do
-        %__MODULE__{arch: arch, os: os, abi: abi}
-      end
+    if arch && os && abi do
+      %__MODULE__{arch: arch, os: os, abi: abi}
     end
   end
 

--- a/lib/zig/templates/build.zig.eex
+++ b/lib/zig/templates/build.zig.eex
@@ -83,6 +83,10 @@ pub fn build(b: *std.Build) void {
     nif.addIncludePath(.{.cwd_relative = "<%= include_dir %>"});
     <% end %>
 
+    <%= for library_dir <- @c.library_dirs do %>
+    nif.addLibraryPath(.{.cwd_relative = "<%= library_dir %>"});
+    <% end %>
+
     <%= for {src, src_opts} <- @c.src do %>
     <% ccompileparams = Enum.map_join(src_opts, ", ", &~s("#{&1}")) %>
     nif.addCSourceFile(.{.file = .{.cwd_relative = "<%= src %>"}, .flags = &[_][]const u8{<%= ccompileparams %>}});


### PR DESCRIPTION
This PR does 2 things:

* Allows passing `library_dirs` option to the `c` config when `use`ing `Zig`
* Removes the requirement that `Mix.target() == :host` to update the target using environment variables