### PR TITLE
Support runtime library rpaths

### DIFF
--- a/lib/zig.ex
+++ b/lib/zig.ex
@@ -406,6 +406,9 @@ defmodule Zig do
   - `include_dirs`: a path or list of paths to search for C header files.
   - `library_dirs`: a path or list of paths to search for C libraries.
   - `link_lib`: a path or list of libraries to link against.
+  - `rpaths`: a path or list of runtime library search paths to embed. Use
+    `{:special, "$ORIGIN"}` for loader-relative paths such as bundled shared
+    libraries placed next to the NIF.
   - `link_libcpp`: if set to `true`, the C++ standard library will be linked.
   - `src`: a list of C source files to compile.  Each source file can be a tuple
     of the form `{path, options}` where `path` is the path to the source file and
@@ -416,6 +419,7 @@ defmodule Zig do
           include_dirs: c_path | [c_path],
           library_dirs: c_path | [c_path],
           link_lib: c_path | [c_path],
+          rpaths: c_path | [c_path],
           link_libcpp: boolean,
           src: [c_path | {c_path, [compiler_options :: String.t()]}]
         ]

--- a/lib/zig/_c.ex
+++ b/lib/zig/_c.ex
@@ -7,6 +7,7 @@ defmodule Zig.C do
   defstruct include_dirs: [],
             library_dirs: [],
             link_lib: [],
+            rpaths: [],
             src: [],
             link_libc: true,
             link_libcpp: false
@@ -19,6 +20,7 @@ defmodule Zig.C do
           include_dirs: [String.t() | {:system, String.t()}],
           library_dirs: [String.t() | {:system, String.t()}],
           link_lib: [String.t() | {:system, String.t()}],
+          rpaths: [String.t()],
           link_libc: boolean,
           link_libcpp: boolean,
           src: [{String.t(), [String.t()]}]
@@ -31,6 +33,7 @@ defmodule Zig.C do
     |> Options.normalize_kw(:include_dirs, [], &normalize_pathlist/2, context)
     |> Options.normalize_kw(:library_dirs, [], &normalize_pathlist/2, context)
     |> Options.normalize_kw(:link_lib, [], &normalize_pathlist/2, context)
+    |> Options.normalize_kw(:rpaths, [], &normalize_rpaths/2, context)
     |> Options.normalize_kw(:src, [], &normalize_c_src/2, context)
     |> Options.validate(:link_libcpp, :boolean, context)
     |> then(&struct!(__MODULE__, &1))
@@ -76,6 +79,34 @@ defmodule Zig.C do
         context
       )
   end
+
+  def normalize_rpaths([n | _] = charlist, context) when is_integer(n),
+    do: [normalize_rpath("#{charlist}", context)]
+
+  def normalize_rpaths(path_or_paths, context) do
+    path_or_paths
+    |> List.wrap()
+    |> Enum.map(&normalize_rpath(&1, context))
+  end
+
+  defp normalize_rpath({:special, path}, context) do
+    path =
+      path
+      |> IO.iodata_to_binary()
+      |> validate_special_rpath(context)
+
+    {:special, path}
+  rescue
+    _ in ArgumentError ->
+      Options.raise_with("special rpath must be iodata", path, context)
+  end
+
+  defp normalize_rpath(path, context), do: resolve_path(path, context)
+
+  defp validate_special_rpath("", context),
+    do: Options.raise_with("special rpath cannot be empty", context)
+
+  defp validate_special_rpath(path, _context), do: path
 
   def normalize_c_src([n | _] = charlist, context) when is_integer(n),
     do: [{resolve_path("#{charlist}", context), []}]

--- a/lib/zig/_module.ex
+++ b/lib/zig/_module.ex
@@ -598,6 +598,15 @@ defmodule Zig.Module do
           "#{mode}.addObjectFile(.{.cwd_relative = \"#{path}\"});"
       end)
 
+    rpaths =
+      Enum.map(c.rpaths, fn
+        {:special, path} ->
+          "#{mode}.root_module.addRPathSpecial(\"#{escape(path)}\");"
+
+        path ->
+          "#{mode}.root_module.addRPath(.{.cwd_relative = \"#{escape(path)}\"});"
+      end)
+
     c_srcs =
       Enum.map(c.src, fn
         {c_src, flags} ->
@@ -610,7 +619,7 @@ defmodule Zig.Module do
           """
       end)
 
-    link_libs ++ c_srcs
+    link_libs ++ rpaths ++ c_srcs
   end
 
   defp render_flags(flags) do

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -144,6 +144,27 @@ defmodule ZiglerTest.OptionsTest do
                )
     end
 
+    test "rpaths accepts paths and special loader-relative forms" do
+      local_dir = Path.join(__DIR__, "my_dir")
+      priv_dir = Path.join(:code.priv_dir(:zigler), "my_dir")
+
+      assert %{c: %{rpaths: [^local_dir]}} = make_module(otp_app: :zigler, c: [rpaths: "my_dir"])
+
+      assert %{c: %{rpaths: [^priv_dir]}} =
+               make_module(otp_app: :zigler, c: [rpaths: {:priv, "my_dir"}])
+
+      assert %{c: %{rpaths: [special: "$ORIGIN"]}} =
+               make_module(otp_app: :zigler, c: [rpaths: {:special, "$ORIGIN"}])
+    end
+
+    test "rpaths not a string list" do
+      assert_raise CompileError,
+                   "test/options_test.exs:4: option `c > rpaths` must be #{@valid_type_phrase}, got: `:moop`",
+                   fn ->
+                     make_module(otp_app: :zigler, c: [rpaths: :moop])
+                   end
+    end
+
     test "link_lib not a string list" do
       assert_raise CompileError,
                    "test/options_test.exs:4: option `c > link_lib` must be #{@valid_type_phrase}, got: `:moop`",


### PR DESCRIPTION
Add a `c: [rpaths: ...]` option for embedding runtime library search paths in generated Zig builds.

This supports packages that bundle shared libraries next to their NIFs, e.g. `{:special, "$ORIGIN"}` for Linux loader-relative paths.

Validated with:

```bash
mix test test/options_test.exs
```
