### PR TITLE
templates: add -Dnif_linkage build option

### DIFF
--- a/lib/zig/templates/build_mod.zig.eex
+++ b/lib/zig/templates/build_mod.zig.eex
@@ -10,6 +10,12 @@ pub fn build(b: *std.Build) void {
 
     const mode = b.option(BuildMode, "zigler-mode", "Build either the nif library or the sema analysis module") orelse .nif_lib;
 
+    // `nif_linkage` controls whether the produced NIF is a dynamic
+    // library (default — what a host BEAM dlopens from priv/) or a
+    // static archive (.a — needed when linking the NIF into an
+    // embedded BEAM that doesn't have dlopen, e.g. iOS device).
+    const nif_linkage = b.option(std.builtin.LinkMode, "nif_linkage", "NIF library linkage — dynamic (host) or static (embedded/iOS)") orelse .dynamic;
+
     <%= for {name, _} <- @dependencies do %>
     const <%= name %> = b.dependency("<%= name %>", .{
         .target = resolved_target,
@@ -29,7 +35,7 @@ pub fn build(b: *std.Build) void {
 
             const lib = b.addLibrary(.{
                 .name = "<%= @module %>",
-                .linkage = .dynamic,
+                .linkage = nif_linkage,
                 .version = .{.major = <%= @version.major %>,
                              .minor = <%= @version.minor %>,
                              .patch = <%= @version.patch %>},
@@ -39,7 +45,13 @@ pub fn build(b: *std.Build) void {
             <%= render_c(@c, :lib) %>
             <%= for extra_module <- @extra_modules, do: render_c(extra_module, :lib) %>
 
-            lib.linker_allow_shlib_undefined = true;
+            // Static archives can't have unresolved symbols deferred to
+            // load-time (that's a shared-library concept). Skip the flag
+            // when the user requested a staticlib — the linker that
+            // eventually consumes the .a will resolve the `enif_*` etc.
+            if (nif_linkage == .dynamic) {
+                lib.linker_allow_shlib_undefined = true;
+            }
 
             // the native backend still causes segfaults, so we must disable it for now.
             lib.use_llvm = true;


### PR DESCRIPTION
Adds a build-time option to produce a static archive (`.a`) instead of the default dynamic library (`.so` / `.dylib` / `.dll`). Useful for any target where the BEAM doesn't have `dlopen` and the NIF needs to be linked directly into the BEAM binary — iOS device is the immediate motivator, but the same applies to embedded / kiosk / single-binary builds generally.

## Usage

```
zig build -Dnif_linkage=dynamic     # default — .so/.dylib/.dll
zig build -Dnif_linkage=static      # .a, linked into the BEAM binary by the consumer
```

## Implementation

`nif_linkage` is a `std.builtin.LinkMode` option that flows directly into `b.addLibrary(.linkage = ...)`. The existing `lib.linker_allow_shlib_undefined = true` flag is gated on `dynamic` linkage — that flag is a shared-library concept, and with a `.a` the eventual link step that consumes it (the consumer's BEAM build) resolves the deferred `enif_*` etc.

Roughly 12 net lines in `lib/zig/templates/build_mod.zig.eex`.

## How it's used in production

[Mob](https://github.com/GenericJam/mob), a framework for shipping BEAM apps on iOS and Android. Mob statically links Zigler NIFs into the same `.so` / app binary as `libbeam.a`. Verified end-to-end with a Zig NIF compiled at `nif_linkage=static` linked alongside a Rust NIF on iPhone and Android. Without this option Mob was carrying a downstream fork patch.

## Relation to other PRs in this set

Independent of the other PRs I'm submitting alongside this one. Useful in combination with a per-NIF init-symbol alias (separate PR — when multiple statically-linked NIFs are present, the bare `nif_init` symbol collides across modules and needs aliasing).

This work was Claude-assisted; the commit carries a `Co-Authored-By: Claude` trailer.

Edit by human:
Using in Mob - https://hexdocs.pm/mob_dev/nifs.html#zig-via-zigler
I'd prefer to use the official repo to my own fork but I understand if AI code is not acceptable. Take anything that's useful. I don't need credit.