### PR TITLE
templates: -Dnif_init_alias for static-NIF table linking

### DIFF
--- a/lib/zig/templates/build_mod.zig.eex
+++ b/lib/zig/templates/build_mod.zig.eex
@@ -10,6 +10,23 @@ pub fn build(b: *std.Build) void {
 
     const mode = b.option(BuildMode, "zigler-mode", "Build either the nif library or the sema analysis module") orelse .nif_lib;
 
+    // For static-linked NIFs, BEAM's `erts_static_nif_tab[]` lookup
+    // matches a symbol named `<modname>_nif_init`. Zigler's default
+    // export name is plain `nif_init` (matches the dlopen path). When
+    // the consumer wants the static-table form, they pass
+    // `-Dnif_init_alias=<name>_nif_init` and the emitted nif_init is
+    // exported under that name instead. The bare symbol is suppressed
+    // to avoid duplicate-symbol collisions when multiple static NIFs
+    // (e.g. Rustler + Zigler) are linked into one binary. Empty string
+    // = host build, default `nif_init` export.
+    const nif_init_alias = b.option([]const u8, "nif_init_alias", "Exported symbol name for nif_init when linking into a static-NIF table (e.g. `<name>_nif_init`); default is `nif_init` for the dlopen path") orelse "";
+
+    // Thread nif_init_alias into module.zig via b.addOptions. The
+    // module's `comptime` block consumes the option to pick the export
+    // name. See module.zig.eex.
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "nif_init_alias", nif_init_alias);
+
     <%= for {name, _} <- @dependencies do %>
     const <%= name %> = b.dependency("<%= name %>", .{
         .target = resolved_target,
@@ -26,6 +43,11 @@ pub fn build(b: *std.Build) void {
             <%= for extra_module <- @extra_modules, do: Builder.render_build(extra_module)%>
             <%= Builder.render_build(BuildModule.from_beam_module(assigns)) %>
             <%= Builder.render_build(BuildModule.nif_shim()) %>
+
+            // Make build_options visible to nif_shim (which contains
+            // module.zig's `nif_init`). The shim picks the @export name
+            // from `nif_init_alias` — see module.zig for the consumer.
+            nif_shim.addImport("build_options", build_options.createModule());
 
             const lib = b.addLibrary(.{
                 .name = "<%= @module %>",

--- a/lib/zig/templates/module.zig.eex
+++ b/lib/zig/templates/module.zig.eex
@@ -6,6 +6,29 @@ const Resource = beam.Resource;
 const root = @This();
 const threads = beam.threads;
 const builtin = @import("builtin");
+const build_options = @import("build_options");
+const std_ = @import("std");
+
+// Static-link builds (embedded BEAM, e.g. iOS) can't tolerate the
+// default panic handler — it pulls in `std.debug.SelfInfo` for
+// stack-trace resolution, which on Mach-O references dyld functions
+// like `_dyld_get_image_header_containing_address`. Those aren't
+// linkable in a static archive destined for an embedded BEAM that
+// doesn't ship its own dyld.
+//
+// When `nif_init_alias` is set (our marker for static-link mode),
+// swap to `std.debug.no_panic` — a trap-only panic that emits no
+// stdlib introspection. NIF-level errors still surface to BEAM via
+// the normal `erlang:error` path; only Zig-language `@panic` calls
+// trap silently.
+//
+// Host builds (no alias) get the default panic — readable backtraces,
+// stderr-printed messages, all the usual stdlib introspection. They
+// have a host BEAM with dyld so there's nothing to link-break.
+pub const panic = if (build_options.nif_init_alias.len > 0)
+    std_.debug.no_panic
+else
+    std_.debug.simple_panic;
 
 <%= for nif <- @nifs do %>
 <%= Nif.render_zig(nif) %>
@@ -70,10 +93,27 @@ export fn nif_init(callbacks: [*c]e.TWinDynNifCallbacks) callconv(.winapi) [*c]c
     return &entry;
 }
 <% _ -> %>
-export fn nif_init() *const e.ErlNifEntry {
+fn nif_init() callconv(.c) *const e.ErlNifEntry {
     return &entry;
 }
 <% end %>
+
+// Static-NIF table lookup matches `<modname>_nif_init`. When the
+// consumer (e.g. an embedded BEAM on iOS) passes a non-empty
+// `-Dnif_init_alias=<name>` to `zig build`, emit ONLY that aliased
+// name and suppress the bare `nif_init`. Suppressing matters because
+// when several static NIF archives are linked into one binary, each
+// one's bare `nif_init` collides at link time — ld may merge them
+// and the per-module aliased symbol ends up pointing at another
+// crate's code (verified failure mode with Rustler). Empty alias =
+// host build, export the standard `nif_init` so dlopen works.
+comptime {
+    const nif_init_link_name = if (build_options.nif_init_alias.len > 0)
+        build_options.nif_init_alias
+    else
+        "nif_init";
+    @export(&nif_init, .{ .name = nif_init_link_name });
+}
 
 fn sectionName() []const u8 {
     return switch (builtin.target.ofmt) {


### PR DESCRIPTION
Adds `-Dnif_init_alias=<name>` to control the exported name of `nif_init`. Useful when linking a Zig NIF into an embedded BEAM that looks the init function up by `<modname>_nif_init` in a static table (rather than `dlopen`'ing for the plain `nif_init` symbol).

Also covers a real duplicate-symbol failure mode when multiple static NIFs (Rustler + Zigler) are linked into the same binary.

## Usage

```
zig build                                # default — exports `nif_init`
zig build -Dnif_init_alias=foo_nif_init  # exports only `foo_nif_init`
```

## What changed

**`build_mod.zig.eex`** — adds the option, threads it into the rendered module via `b.addOptions` + an `addImport("build_options", ...)` on `nif_shim`.

**`module.zig.eex`** — switches `nif_init` from `export fn` to plain `fn ... callconv(.c)`, then exports it via a `comptime` block under either the aliased name (when set) or the default `nif_init`. Suppressing the bare name when an alias is requested prevents the duplicate-symbol collision noted below.

**`module.zig.eex`** — swaps the panic handler conditionally: `std.debug.no_panic` when `nif_init_alias` is set (our marker for static-link mode), `std.debug.simple_panic` otherwise. Static-link builds destined for an embedded BEAM can't reference `std.debug.SelfInfo`, which pulls in dyld symbols like `_dyld_get_image_header_containing_address` the consuming binary doesn't have. NIF-level errors still surface to BEAM via the normal `erlang:error` flow; only language-level `@panic` calls trap silently in the embedded build. Host builds keep readable stderr panic messages.

## Failure mode this fixes

`mix mob` app with both a Rustler-backed and a Zigler-backed NIF statically linked into one iOS app binary. Without alias suppression, `nm` shows duplicate `_nif_init`; Apple `ld` picks one definition and silently merges the others. Disassembly of `_greet_zig_nif_init` shows a tail-call to `_greet_rust_nif_init` followed by a return of Rust's entry pointer. Runtime symptom: `:erlang.load_nif/2` returns `:ok` but every Zig NIF function reports `"nif for function <name>/N not bound"`. The duplicate-symbol warning from `ld` is easy to miss in a normal build log.

## Relation to other PRs in this set

Conceptually pairs with `-Dnif_linkage=static` (#582 in this set) — the alias is only useful in static-link mode — but the diffs are independent and either can land first. The panic swap is bundled here because it gates on `nif_init_alias`; happy to reframe it to gate on `nif_linkage == .static` instead once that option lands, if you'd prefer the conditions on the same flag.

Verified in production via [Mob](https://github.com/GenericJam/mob) — three concurrent NIFs (C, Rust, Zig) statically linked into one iOS / Android app binary, all initialise and respond to Erlang RPC.

Claude-assisted; commit carries the trailer.

Edit by human:
Using in Mob - https://hexdocs.pm/mob_dev/nifs.html#zig-via-zigler
I'd prefer to use the official repo to my own fork but I understand if AI code is not acceptable. Take anything that's useful. I don't need credit.