### PR TITLE
ensure target priv/lib directory exists before copying precompiled .so

### DIFF
--- a/lib/zig/command.ex
+++ b/lib/zig/command.ex
@@ -255,6 +255,7 @@ defmodule Zig.Command do
 
     if force_reload or lib_missing do
       Logger.debug("transferring cached library from #{module.precompiled} to #{dst_lib_path}")
+      File.mkdir_p!(lib_dir)
       # on MacOS, we must delete the old library because otherwise library
       # integrity checker will kill the process
       File.rm(dst_lib_path)


### PR DESCRIPTION
## Summary

When a dependent project does a fresh compile `Zig.Command.compile!/1` fails with a `File.CopyError` ("no such file or directory") even though the source `.so` file is present — the missing piece is the destination directory.

This adds `File.mkdir_p!(lib_dir)` before the copy to ensure the target directory is created if it doesn't already exist.

## Current behavior

  ```
  ➜  uname -a
Linux pop-os 6.17.9-76061709-generic #202511241048~1764607909~24.04~df6b2b6 SMP PREEMPT_DYNAMIC Mon D x86_64 x86_64 x86_64 GNU/Linux

  ➜  mix compile
  Compiling 48 files (.ex)

  11:21:17.412 [debug] skipping compile step for precompiled module
  Elixir.ElixirOpentui.NIF, at
  /tmp/Elixir.ElixirOpentui.NIF/Elixir.ElixirOpentui.NIF.x86_64-linux-gnu.so

  11:21:17.413 [debug] destination library path: /home/alex/gh_ashneyderman/bun-temp/elix
  ir-opentui/_build/dev/lib/elixir_opentui/priv/lib/Elixir.ElixirOpentui.NIF.so

  11:21:17.413 [debug] transferring cached library from
  /tmp/Elixir.ElixirOpentui.NIF/Elixir.ElixirOpentui.NIF.x86_64-linux-gnu.so to
  /home/alex/gh_ashneyderman/bun-temp/elixir-opentui/_build/dev/lib/elixir_opentui/priv/l
  ib/Elixir.ElixirOpentui.NIF.so

  == Compilation error in file lib/elixir_opentui/nif.ex ==
  ** (File.CopyError) could not copy from
  "/tmp/Elixir.ElixirOpentui.NIF/Elixir.ElixirOpentui.NIF.x86_64-linux-gnu.so" to
  "/home/alex/gh_ashneyderman/bun-temp/elixir-opentui/_build/dev/lib/elixir_opentui/priv/
  lib/Elixir.ElixirOpentui.NIF.so": no such file or directory
      (elixir 1.19.4) lib/file.ex:1080: File.cp!/3
      (zigler 0.16.0) lib/zig/command.ex:261: Zig.Command.compile!/1
      (zigler 0.16.0) lib/zig/compiler.ex:151: Zig.Compiler.compile/3
      (zigler 0.16.0) expanding macro: Zig.Compiler.__before_compile__/1
      lib/elixir_opentui/nif.ex:1: ElixirOpentui.NIF (module)
  elixir-opentui git:(main) ✗
  ➜  ls -al /tmp/Elixir.ElixirOpentui.NIF/Elixir.ElixirOpentui.NIF.x86_64-linux-gnu.so
  -rw-rw-r-- 1 alex alex 3912112 Jun  8 11:21
  /tmp/Elixir.ElixirOpentui.NIF/Elixir.ElixirOpentui.NIF.x86_64-linux-gnu.so
  elixir-opentui git:(main) ✗
  ➜  ll /home/alex/gh_ashneyderman/bun-temp/elixir-opentui/_build/dev/lib/elixir_opentui/
  total 16
  drwxrwxr-x  4 alex alex 4096 Jun  8 11:20 ./
  drwxrwxr-x 17 alex alex 4096 Jun  8 11:19 ../
  drwxrwxr-x  2 alex alex 4096 Jun  8 11:20 ebin/
  drwxrwxr-x  2 alex alex 4096 Jun  8 11:18 .mix/
  ```

## Changes

- `lib/zig/command.ex`: Added `File.mkdir_p!(lib_dir)` call before `File.cp!/3` in the precompiled library transfer path.