### PR TITLE
Include Windows NIF headers in Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Zigler.MixProject do
         licenses: ["MIT"],
         # we need to package the zig BEAM adapters and the c include files as a part
         # of the hex packaging system.
-        files: ~w[lib mix.exs README* LICENSE* VERSIONS* priv/beam],
+        files: ~w[lib mix.exs README* LICENSE* VERSIONS* priv/beam priv/erl_nif_win],
         links: %{
           "GitHub" => "https://github.com/E-xyza/zigler",
           "Zig" => "https://ziglang.org/"

--- a/test/package_test.exs
+++ b/test/package_test.exs
@@ -1,0 +1,11 @@
+defmodule ZiglerTest.PackageTest do
+  use ExUnit.Case, async: true
+
+  test "includes Windows NIF compatibility headers" do
+    files = Mix.Project.config() |> Keyword.fetch!(:package) |> Keyword.fetch!(:files)
+
+    assert "priv/erl_nif_win" in files
+    assert File.regular?("priv/erl_nif_win/erl_nif_win.h")
+    assert File.regular?("priv/erl_nif_win/erl_nif_api_funcs_win.h")
+  end
+end


### PR DESCRIPTION
## Summary

- include `priv/erl_nif_win` in the Hex package
- add a package-configuration regression test using the repository's `ZiglerTest` namespace

These compatibility headers are required when Zigler compiles NIFs on Windows. They exist in the repository but were omitted from published package contents.

## Testing

- `mise exec zig@0.16.0 -- mix format --check-formatted mix.exs test/package_test.exs`
- `mise exec zig@0.16.0 -- mix test test/package_test.exs` — 1 passed
- `mix hex.build --unpack --output /tmp/zigler-pr-package` with Elixir 1.20.2/Zig 0.16.0
- verified both `erl_nif_win.h` and `erl_nif_api_funcs_win.h` in the unpacked package
- validated downstream while building QuickBEAM's Windows NIF
